### PR TITLE
BUG: don't exit in package init for version check

### DIFF
--- a/seccomp.go
+++ b/seccomp.go
@@ -9,6 +9,7 @@
 package seccomp
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -26,6 +27,10 @@ import (
 import "C"
 
 // Exported types
+
+// ErrUnsupportedVersion is returned when the libseccomp version on the system is to low for use
+// with the go bindings.
+var ErrUnsupportedVersion = errors.New("Libseccomp version too low: minimum supported is 2.1.0")
 
 // ScmpArch represents a CPU architecture. Seccomp can restrict syscalls on a
 // per-architecture basis.
@@ -405,6 +410,9 @@ type ScmpFilter struct {
 // Returns a reference to a valid filter context, or nil and an error if the
 // filter context could not be created or an invalid default action was given.
 func NewFilter(defaultAction ScmpAction) (*ScmpFilter, error) {
+	if !checkVersionAbove(2, 1, 0) {
+		return nil, ErrUnsupportedVersion
+	}
 	if err := sanitizeAction(defaultAction); err != nil {
 		return nil, err
 	}

--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -7,7 +7,6 @@ package seccomp
 
 import (
 	"fmt"
-	"os"
 	"syscall"
 )
 
@@ -165,14 +164,6 @@ func checkVersionAbove(major, minor, micro int) bool {
 	return (verMajor > major) ||
 		(verMajor == major && verMinor > minor) ||
 		(verMajor == major && verMinor == minor && verMicro >= micro)
-}
-
-// Init function: Verify library version is appropriate
-func init() {
-	if !checkVersionAbove(2, 1, 0) {
-		fmt.Fprintf(os.Stderr, "Libseccomp version too low: minimum supported is 2.1.0, detected %d.%d.%d", C.C_VERSION_MAJOR, C.C_VERSION_MINOR, C.C_VERSION_MICRO)
-		os.Exit(-1)
-	}
 }
 
 // Filter helpers


### PR DESCRIPTION
It is horrible to have a package exit your application in its init
without the consumer being able to do anything about it.  It is better
to return and error if the lib version is too low and have the consumer
of your package decide what to do instead of exit their application.
This changes it to return a typed error if the lib is to low whenever
you try to create a filter instead of doing this check in init()

Signed-off-by: Michael Crosby crosbymichael@gmail.com
