### PR TITLE
seccomp: use pkg-config for cgo flag generation

### DIFF
--- a/seccomp.go
+++ b/seccomp.go
@@ -20,7 +20,7 @@ import (
 
 // C wrapping code
 
-// #cgo LDFLAGS: -lseccomp
+// #cgo pkg-config: libseccomp
 // #include <stdlib.h>
 // #include <seccomp.h>
 import "C"

--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -15,7 +15,7 @@ import (
 // Get the seccomp header in scope
 // Need stdlib.h for free() on cstrings
 
-// #cgo LDFLAGS: -lseccomp
+// #cgo pkg-config: libseccomp
 /*
 #include <stdlib.h>
 #include <seccomp.h>


### PR DESCRIPTION
Not all distributions package libseccomp in the same way, but pkg-config
allows the same configuration to work on different distributions. Switch
to using pkg-config to automatically figure out what the correct
commandline flags are for libseccomp.

Signed-off-by: Aleksa Sarai <asarai@suse.de>