### PR TITLE
RFE: introduce ErrSyscallDoesNotExists error type

### DIFF
--- a/seccomp.go
+++ b/seccomp.go
@@ -168,6 +168,10 @@ const (
 	CompareMaskedEqual ScmpCompareOp = iota
 )
 
+var (
+	ErrSyscallDoesNotExist = fmt.Errorf("could not resolve syscall name")
+)
+
 // Helpers for types
 
 // GetArchFromString returns an ScmpArch constant from a string representing an
@@ -350,7 +354,7 @@ func (s ScmpSyscall) GetNameByArch(arch ScmpArch) (string, error) {
 
 	cString := C.seccomp_syscall_resolve_num_arch(arch.toNative(), C.int(s))
 	if cString == nil {
-		return "", fmt.Errorf("could not resolve syscall name")
+		return "", ErrSyscallDoesNotExist
 	}
 	defer C.free(unsafe.Pointer(cString))
 
@@ -373,7 +377,7 @@ func GetSyscallFromName(name string) (ScmpSyscall, error) {
 
 	result := C.seccomp_syscall_resolve_name(cString)
 	if result == scmpError {
-		return 0, fmt.Errorf("could not resolve name to syscall")
+		return 0, ErrSyscallDoesNotExist
 	}
 
 	return ScmpSyscall(result), nil
@@ -397,7 +401,7 @@ func GetSyscallFromNameByArch(name string, arch ScmpArch) (ScmpSyscall, error) {
 
 	result := C.seccomp_syscall_resolve_name_arch(arch.toNative(), cString)
 	if result == scmpError {
-		return 0, fmt.Errorf("could not resolve name to syscall")
+		return 0, ErrSyscallDoesNotExist
 	}
 
 	return ScmpSyscall(result), nil


### PR DESCRIPTION
A small trivial branch that makes the `could not resolve syscall name` its own error type.

This way I can write client code like this:
```
scmpSys, err := GetSyscallFromNameByArch(name, arch)
if err == ErrSyscallDoesNotExist {
    println("warning: skipping %q - not available on %s", name, arch)
} else if err != nil {
    return err
}
```

I.e. it allows me to differentiate an error that I want to ignore from a real error like unsupported architecture or an unsupported underlying library version.

Happy to adjust both the string and the ErrXXX name as you prefer of course.