### PR TITLE
expose improved kernel logging features through libseccomp-golang

### DIFF
--- a/seccomp.go
+++ b/seccomp.go
@@ -137,6 +137,10 @@ const (
 	ActTrace ScmpAction = iota
 	// ActAllow permits the syscall to continue execution
 	ActAllow ScmpAction = iota
+	// ActLog permits the syscall to continue execution after logging it.
+	// This action is only usable when libseccomp API level 3 or higher is
+	// supported.
+	ActLog ScmpAction = iota
 )
 
 const (
@@ -295,6 +299,8 @@ func (a ScmpAction) String() string {
 	case ActTrace:
 		return fmt.Sprintf("Action: Notify tracing processes with code %d",
 			(a >> 16))
+	case ActLog:
+		return "Action: Log system call"
 	case ActAllow:
 		return "Action: Allow system call"
 	default:

--- a/seccomp.go
+++ b/seccomp.go
@@ -328,6 +328,25 @@ func GetLibraryVersion() (major, minor, micro uint) {
 	return verMajor, verMinor, verMicro
 }
 
+// GetApi returns the API level supported by the system.
+// Returns a positive int containing the API level, or 0 with an error if the
+// API level could not be detected due to the library being older than v2.4.0.
+// See the seccomp_api_get(3) man page for details on available API levels:
+// https://github.com/seccomp/libseccomp/blob/master/doc/man/man3/seccomp_api_get.3
+func GetApi() (uint, error) {
+	return getApi()
+}
+
+// SetApi forcibly sets the API level. General use of this function is strongly
+// discouraged.
+// Returns an error if the API level could not be set. An error is always
+// returned if the library is older than v2.4.0
+// See the seccomp_api_get(3) man page for details on available API levels:
+// https://github.com/seccomp/libseccomp/blob/master/doc/man/man3/seccomp_api_get.3
+func SetApi(api uint) error {
+	return setApi(api)
+}
+
 // Syscall functions
 
 // GetName retrieves the name of a syscall from its number.

--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -74,10 +74,18 @@ const uint32_t C_ACT_ERRNO         = SCMP_ACT_ERRNO(0);
 const uint32_t C_ACT_TRACE         = SCMP_ACT_TRACE(0);
 const uint32_t C_ACT_ALLOW         = SCMP_ACT_ALLOW;
 
+// The libseccomp SCMP_FLTATR_CTL_LOG member of the scmp_filter_attr enum was
+// added in v2.4.0
+#if (SCMP_VER_MAJOR < 2) || \
+    (SCMP_VER_MAJOR == 2 && SCMP_VER_MINOR < 4)
+#define SCMP_FLTATR_CTL_LOG _SCMP_FLTATR_MIN
+#endif
+
 const uint32_t C_ATTRIBUTE_DEFAULT = (uint32_t)SCMP_FLTATR_ACT_DEFAULT;
 const uint32_t C_ATTRIBUTE_BADARCH = (uint32_t)SCMP_FLTATR_ACT_BADARCH;
 const uint32_t C_ATTRIBUTE_NNP     = (uint32_t)SCMP_FLTATR_CTL_NNP;
 const uint32_t C_ATTRIBUTE_TSYNC   = (uint32_t)SCMP_FLTATR_CTL_TSYNC;
+const uint32_t C_ATTRIBUTE_LOG     = (uint32_t)SCMP_FLTATR_CTL_LOG;
 
 const int      C_CMP_NE            = (int)SCMP_CMP_NE;
 const int      C_CMP_LT            = (int)SCMP_CMP_LT;
@@ -179,6 +187,7 @@ const (
 	filterAttrActBadArch scmpFilterAttr = iota
 	filterAttrNNP        scmpFilterAttr = iota
 	filterAttrTsync      scmpFilterAttr = iota
+	filterAttrLog        scmpFilterAttr = iota
 )
 
 const (
@@ -545,6 +554,8 @@ func (a scmpFilterAttr) toNative() uint32 {
 		return uint32(C.C_ATTRIBUTE_NNP)
 	case filterAttrTsync:
 		return uint32(C.C_ATTRIBUTE_TSYNC)
+	case filterAttrLog:
+		return uint32(C.C_ATTRIBUTE_LOG)
 	default:
 		return 0x0
 	}

--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -68,10 +68,15 @@ const uint32_t C_ARCH_PPC64LE      = SCMP_ARCH_PPC64LE;
 const uint32_t C_ARCH_S390         = SCMP_ARCH_S390;
 const uint32_t C_ARCH_S390X        = SCMP_ARCH_S390X;
 
+#ifndef SCMP_ACT_LOG
+#define SCMP_ACT_LOG 0x7ffc0000U
+#endif
+
 const uint32_t C_ACT_KILL          = SCMP_ACT_KILL;
 const uint32_t C_ACT_TRAP          = SCMP_ACT_TRAP;
 const uint32_t C_ACT_ERRNO         = SCMP_ACT_ERRNO(0);
 const uint32_t C_ACT_TRACE         = SCMP_ACT_TRACE(0);
+const uint32_t C_ACT_LOG           = SCMP_ACT_LOG;
 const uint32_t C_ACT_ALLOW         = SCMP_ACT_ALLOW;
 
 // The libseccomp SCMP_FLTATR_CTL_LOG member of the scmp_filter_attr enum was
@@ -198,7 +203,7 @@ const (
 	archEnd   ScmpArch = ArchS390X
 	// Comparison boundaries to check for action validity
 	actionStart ScmpAction = ActKill
-	actionEnd   ScmpAction = ActAllow
+	actionEnd   ScmpAction = ActLog
 	// Comparison boundaries to check for comparison operator validity
 	compareOpStart ScmpCompareOp = CompareNotEqual
 	compareOpEnd   ScmpCompareOp = CompareMaskedEqual
@@ -518,6 +523,8 @@ func actionFromNative(a C.uint32_t) (ScmpAction, error) {
 		return ActErrno.SetReturnCode(int16(aTmp)), nil
 	case C.C_ACT_TRACE:
 		return ActTrace.SetReturnCode(int16(aTmp)), nil
+	case C.C_ACT_LOG:
+		return ActLog, nil
 	case C.C_ACT_ALLOW:
 		return ActAllow, nil
 	default:
@@ -536,6 +543,8 @@ func (a ScmpAction) toNative() C.uint32_t {
 		return C.C_ACT_ERRNO | (C.uint32_t(a) >> 16)
 	case ActTrace:
 		return C.C_ACT_TRACE | (C.uint32_t(a) >> 16)
+	case ActLog:
+		return C.C_ACT_LOG
 	case ActAllow:
 		return C.C_ACT_ALLOW
 	default:

--- a/seccomp_test.go
+++ b/seccomp_test.go
@@ -596,3 +596,75 @@ func TestRuleAddAndLoad(t *testing.T) {
 		t.Errorf("Syscall returned incorrect error code - likely not blocked by Seccomp!")
 	}
 }
+
+func TestLogAct(t *testing.T) {
+	expectedPid := syscall.Getpid()
+
+	api, err := GetApi()
+	if err != nil {
+		if !ApiLevelIsSupported() {
+			t.Skipf("Skipping test: %s", err)
+		}
+
+		t.Errorf("Error getting API level: %s", err)
+	} else if api < 3 {
+		t.Skipf("Skipping test: API level %d is less than 3", api)
+	}
+
+	filter, err := NewFilter(ActErrno.SetReturnCode(0x0001))
+	if err != nil {
+		t.Errorf("Error creating filter: %s", err)
+	}
+	defer filter.Release()
+
+	call, err := GetSyscallFromName("getpid")
+	if err != nil {
+		t.Errorf("Error getting syscall number of getpid: %s", err)
+	}
+
+	call1, err := GetSyscallFromName("write")
+	if err != nil {
+		t.Errorf("Error getting syscall number of write: %s", err)
+	}
+
+	call2, err := GetSyscallFromName("futex")
+	if err != nil {
+		t.Errorf("Error getting syscall number of futex: %s", err)
+	}
+
+	call3, err := GetSyscallFromName("exit_group")
+	if err != nil {
+		t.Errorf("Error getting syscall number of exit_group: %s", err)
+	}
+
+	err = filter.AddRule(call, ActLog)
+	if err != nil {
+		t.Errorf("Error adding rule to log syscall: %s", err)
+	}
+
+	err = filter.AddRule(call1, ActAllow)
+	if err != nil {
+		t.Errorf("Error adding rule to allow write syscall: %s", err)
+	}
+
+	err = filter.AddRule(call2, ActAllow)
+	if err != nil {
+		t.Errorf("Error adding rule to allow futex syscall: %s", err)
+	}
+
+	err = filter.AddRule(call3, ActAllow)
+	if err != nil {
+		t.Errorf("Error adding rule to allow exit_group syscall: %s", err)
+	}
+
+	err = filter.Load()
+	if err != nil {
+		t.Errorf("Error loading filter: %s", err)
+	}
+
+	// Try making a simple syscall, it should succeed
+	pid := syscall.Getpid()
+	if pid != expectedPid {
+		t.Errorf("Syscall should have returned expected pid (%d != %d)", pid, expectedPid)
+	}
+}

--- a/seccomp_test.go
+++ b/seccomp_test.go
@@ -432,6 +432,38 @@ func TestFilterAttributeGettersAndSetters(t *testing.T) {
 		t.Errorf("No new privileges bit was not set correctly")
 	}
 
+	if ApiLevelIsSupported() {
+		api, err := GetApi()
+		if err != nil {
+			t.Errorf("Error getting API level: %s", err)
+		} else if api < 3 {
+			err = SetApi(3)
+			if err != nil {
+				t.Errorf("Error setting API level: %s", err)
+			}
+		}
+	}
+
+	err = filter.SetLogBit(true)
+	if err != nil {
+		if !ApiLevelIsSupported() {
+			t.Logf("Ignoring failure: %s\n", err)
+		} else {
+			t.Errorf("Error setting log bit")
+		}
+	}
+
+	log, err := filter.GetLogBit()
+	if err != nil {
+		if !ApiLevelIsSupported() {
+			t.Logf("Ignoring failure: %s\n", err)
+		} else {
+			t.Errorf("Error getting log bit")
+		}
+	} else if log != true {
+		t.Errorf("Log bit was not set correctly")
+	}
+
 	err = filter.SetBadArchAction(ActInvalid)
 	if err == nil {
 		t.Errorf("Setting bad arch action to an invalid action should error")

--- a/seccomp_test.go
+++ b/seccomp_test.go
@@ -64,6 +64,51 @@ func TestVersionError(t *testing.T) {
 	}
 }
 
+func ApiLevelIsSupported() bool {
+	return verMajor > 2 ||
+		(verMajor == 2 && verMinor > 3) ||
+		(verMajor == 2 && verMinor == 3 && verMicro >= 3)
+}
+
+func TestGetApiLevel(t *testing.T) {
+	api, err := GetApi()
+	if !ApiLevelIsSupported() {
+		if api != 0 {
+			t.Errorf("API level returned despite lack of support: %v", api)
+		} else if err == nil {
+			t.Errorf("No error returned despite lack of API level support")
+		}
+
+		t.Skipf("Skipping test: %s", err)
+	} else if err != nil {
+		t.Errorf("Error getting API level: %s", err)
+	}
+	fmt.Printf("Got API level of %v\n", api)
+}
+
+func TestSetApiLevel(t *testing.T) {
+	var expectedApi uint
+
+	expectedApi = 1
+	err := SetApi(expectedApi)
+	if !ApiLevelIsSupported() {
+		if err == nil {
+			t.Errorf("No error returned despite lack of API level support")
+		}
+
+		t.Skipf("Skipping test: %s", err)
+	} else if err != nil {
+		t.Errorf("Error setting API level: %s", err)
+	}
+
+	api, err := GetApi()
+	if err != nil {
+		t.Errorf("Error getting API level: %s", err)
+	} else if api != expectedApi {
+		t.Errorf("Got API level %v: expected %v", api, expectedApi)
+	}
+}
+
 func TestActionSetReturnCode(t *testing.T) {
 	if ActInvalid.SetReturnCode(0x0010) != ActInvalid {
 		t.Errorf("Able to set a return code on invalid action!")


### PR DESCRIPTION
This is a pull request that complements https://github.com/seccomp/libseccomp/pull/92. It is not yet ready for merging as there's some pending work left to do for that libseccomp PR to allow applications, such as the libseccomp and libseccomp-golang test suites, to request/force a certain API level. See https://github.com/seccomp/libseccomp/pull/92#discussion_r138680169 for more context.

The SECCOMP_FILTER_FLAG_LOG filter flag and SECCOMP_RET_LOG action allow applications to have more control over what actions should be logged.

The tests added by this PR pass when run under a kernel that has support for the new filter flag and action and a libseccomp that has been built with https://github.com/seccomp/libseccomp/pull/92. They fail otherwise, pending the API level changes that would allow the libseccomp-golang tests to request a certain API level.