### PR TITLE
README: Update the readme to support markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-libseccomp-golang: Go Language Bindings for the libseccomp Project
+![Enhanced Seccomp Helper Library](https://github.com/seccomp/libseccomp-artwork/blob/master/logo/libseccomp-color_text.png)
 ===============================================================================
-https://github.com/seccomp/libseccomp-golang
-https://github.com/seccomp/libseccomp
+libseccomp-golang: Go Language Bindings for the libseccomp Project
 
 The libseccomp library provides an easy to use, platform independent, interface
 to the Linux Kernel's syscall filtering mechanism.  The libseccomp API is
@@ -12,40 +11,39 @@ be familiar to, and easily adopted by, application developers.
 The libseccomp-golang library provides a Go based interface to the libseccomp
 library.
 
-* Online Resources
+## Online Resources
 
 The library source repository currently lives on GitHub at the following URLs:
 
-	-> https://github.com/seccomp/libseccomp-golang
-	-> https://github.com/seccomp/libseccomp
+* https://github.com/seccomp/libseccomp-golang
+* https://github.com/seccomp/libseccomp
 
 The project mailing list is currently hosted on Google Groups at the URL below,
 please note that a Google account is not required to subscribe to the mailing
 list.
 
-	-> https://groups.google.com/d/forum/libseccomp
+* https://groups.google.com/d/forum/libseccomp
 
 Documentation is also available at:
 
-	-> https://godoc.org/github.com/seccomp/libseccomp-golang
+* https://godoc.org/github.com/seccomp/libseccomp-golang
 
-* Installing the package
+## Installing the package
 
 The libseccomp-golang bindings require at least Go v1.2.1 and GCC v4.8.4;
 earlier versions may yield unpredictable results.  If you meet these
 requirements you can install this package using the command below:
 
-	$ go get github.com/seccomp/libseccomp-golang
+	# go get github.com/seccomp/libseccomp-golang
 
-* Testing the Library
+## Testing the Library
 
 A number of tests and lint related recipes are provided in the Makefile, if
 you want to run the standard regression tests, you can excute the following:
 
-	$ make check
+	# make check
 
 In order to execute the 'make lint' recipe the 'golint' tool is needed, it
 can be found at:
 
-	-> https://github.com/golang/lint
-
+* https://github.com/golang/lint


### PR DESCRIPTION
This commit renames README to README.md and makes the requisite
changes to display the data correctly as a markdown file.  Note
that there were no significant changes to the contents of the
readme itself.

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>

Addresses: bullet number 3 in issue #36 