### PR TITLE
RFE: fix the outstanding "make lint" errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,11 @@ addons:
       - libseccomp2
       - libseccomp-dev
 
+install:
+  - go get -u golang.org/x/lint/golint
+
 # run all of the tests independently, fail if any of the tests error
 script:
   - make check-syntax
+  - make lint
   - make check

--- a/seccomp.go
+++ b/seccomp.go
@@ -345,23 +345,23 @@ func GetLibraryVersion() (major, minor, micro uint) {
 	return verMajor, verMinor, verMicro
 }
 
-// GetApi returns the API level supported by the system.
+// GetAPI returns the API level supported by the system.
 // Returns a positive int containing the API level, or 0 with an error if the
 // API level could not be detected due to the library being older than v2.4.0.
 // See the seccomp_api_get(3) man page for details on available API levels:
 // https://github.com/seccomp/libseccomp/blob/master/doc/man/man3/seccomp_api_get.3
-func GetApi() (uint, error) {
-	return getApi()
+func GetAPI() (uint, error) {
+	return getAPI()
 }
 
-// SetApi forcibly sets the API level. General use of this function is strongly
+// SetAPI forcibly sets the API level. General use of this function is strongly
 // discouraged.
 // Returns an error if the API level could not be set. An error is always
 // returned if the library is older than v2.4.0
 // See the seccomp_api_get(3) man page for details on available API levels:
 // https://github.com/seccomp/libseccomp/blob/master/doc/man/man3/seccomp_api_get.3
-func SetApi(api uint) error {
-	return setApi(api)
+func SetAPI(api uint) error {
+	return setAPI(api)
 }
 
 // Syscall functions
@@ -611,11 +611,11 @@ func (f *ScmpFilter) Merge(src *ScmpFilter) error {
 
 	// Merge the filters
 	if retCode := C.seccomp_merge(f.filterCtx, src.filterCtx); retCode != 0 {
-		if e := errRc(retCode); e == syscall.EINVAL {
+		e := errRc(retCode)
+		if e == syscall.EINVAL {
 			return fmt.Errorf("filters could not be merged due to a mismatch in attributes or invalid filter")
-		} else {
-			return e
 		}
+		return e
 	}
 
 	src.valid = false
@@ -645,12 +645,12 @@ func (f *ScmpFilter) IsArchPresent(arch ScmpArch) (bool, error) {
 	}
 
 	if retCode := C.seccomp_arch_exist(f.filterCtx, arch.toNative()); retCode != 0 {
-		if e := errRc(retCode); e == syscall.EEXIST {
+		e := errRc(retCode)
+		if e == syscall.EEXIST {
 			// -EEXIST is "arch not present"
 			return false, nil
-		} else {
-			return false, e
 		}
+		return false, e
 	}
 
 	return true, nil
@@ -778,7 +778,7 @@ func (f *ScmpFilter) GetNoNewPrivsBit() (bool, error) {
 func (f *ScmpFilter) GetLogBit() (bool, error) {
 	log, err := f.getFilterAttr(filterAttrLog)
 	if err != nil {
-		api, apiErr := getApi()
+		api, apiErr := getAPI()
 		if (apiErr != nil && api == 0) || (apiErr == nil && api < 3) {
 			return false, fmt.Errorf("getting the log bit is only supported in libseccomp 2.4.0 and newer with API level 3 or higher")
 		}
@@ -832,7 +832,7 @@ func (f *ScmpFilter) SetLogBit(state bool) error {
 
 	err := f.setFilterAttr(filterAttrLog, toSet)
 	if err != nil {
-		api, apiErr := getApi()
+		api, apiErr := getAPI()
 		if (apiErr != nil && api == 0) || (apiErr == nil && api < 3) {
 			return fmt.Errorf("setting the log bit is only supported in libseccomp 2.4.0 and newer with API level 3 or higher")
 		}

--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -246,7 +246,7 @@ func ensureSupportedVersion() error {
 }
 
 // Get the API level
-func getApi() (uint, error) {
+func getAPI() (uint, error) {
 	api := C.seccomp_api_get()
 	if api == 0 {
 		return 0, fmt.Errorf("API level operations are not supported")
@@ -256,7 +256,7 @@ func getApi() (uint, error) {
 }
 
 // Set the API level
-func setApi(api uint) error {
+func setAPI(api uint) error {
 	if retCode := C.seccomp_api_set(C.uint(api)); retCode != 0 {
 		if errRc(retCode) == syscall.EOPNOTSUPP {
 			return fmt.Errorf("API level operations are not supported")

--- a/seccomp_test.go
+++ b/seccomp_test.go
@@ -64,15 +64,15 @@ func TestVersionError(t *testing.T) {
 	}
 }
 
-func ApiLevelIsSupported() bool {
+func APILevelIsSupported() bool {
 	return verMajor > 2 ||
 		(verMajor == 2 && verMinor > 3) ||
 		(verMajor == 2 && verMinor == 3 && verMicro >= 3)
 }
 
-func TestGetApiLevel(t *testing.T) {
-	api, err := GetApi()
-	if !ApiLevelIsSupported() {
+func TestGetAPILevel(t *testing.T) {
+	api, err := GetAPI()
+	if !APILevelIsSupported() {
 		if api != 0 {
 			t.Errorf("API level returned despite lack of support: %v", api)
 		} else if err == nil {
@@ -86,12 +86,12 @@ func TestGetApiLevel(t *testing.T) {
 	fmt.Printf("Got API level of %v\n", api)
 }
 
-func TestSetApiLevel(t *testing.T) {
-	var expectedApi uint
+func TestSetAPILevel(t *testing.T) {
+	var expectedAPI uint
 
-	expectedApi = 1
-	err := SetApi(expectedApi)
-	if !ApiLevelIsSupported() {
+	expectedAPI = 1
+	err := SetAPI(expectedAPI)
+	if !APILevelIsSupported() {
 		if err == nil {
 			t.Errorf("No error returned despite lack of API level support")
 		}
@@ -101,11 +101,11 @@ func TestSetApiLevel(t *testing.T) {
 		t.Errorf("Error setting API level: %s", err)
 	}
 
-	api, err := GetApi()
+	api, err := GetAPI()
 	if err != nil {
 		t.Errorf("Error getting API level: %s", err)
-	} else if api != expectedApi {
-		t.Errorf("Got API level %v: expected %v", api, expectedApi)
+	} else if api != expectedAPI {
+		t.Errorf("Got API level %v: expected %v", api, expectedAPI)
 	}
 }
 
@@ -432,12 +432,12 @@ func TestFilterAttributeGettersAndSetters(t *testing.T) {
 		t.Errorf("No new privileges bit was not set correctly")
 	}
 
-	if ApiLevelIsSupported() {
-		api, err := GetApi()
+	if APILevelIsSupported() {
+		api, err := GetAPI()
 		if err != nil {
 			t.Errorf("Error getting API level: %s", err)
 		} else if api < 3 {
-			err = SetApi(3)
+			err = SetAPI(3)
 			if err != nil {
 				t.Errorf("Error setting API level: %s", err)
 			}
@@ -446,7 +446,7 @@ func TestFilterAttributeGettersAndSetters(t *testing.T) {
 
 	err = filter.SetLogBit(true)
 	if err != nil {
-		if !ApiLevelIsSupported() {
+		if !APILevelIsSupported() {
 			t.Logf("Ignoring failure: %s\n", err)
 		} else {
 			t.Errorf("Error setting log bit")
@@ -455,7 +455,7 @@ func TestFilterAttributeGettersAndSetters(t *testing.T) {
 
 	log, err := filter.GetLogBit()
 	if err != nil {
-		if !ApiLevelIsSupported() {
+		if !APILevelIsSupported() {
 			t.Logf("Ignoring failure: %s\n", err)
 		} else {
 			t.Errorf("Error getting log bit")
@@ -600,9 +600,9 @@ func TestRuleAddAndLoad(t *testing.T) {
 func TestLogAct(t *testing.T) {
 	expectedPid := syscall.Getpid()
 
-	api, err := GetApi()
+	api, err := GetAPI()
 	if err != nil {
-		if !ApiLevelIsSupported() {
+		if !APILevelIsSupported() {
 			t.Skipf("Skipping test: %s", err)
 		}
 
@@ -681,9 +681,9 @@ func TestCreateActKillThreadFilter(t *testing.T) {
 }
 
 func TestCreateActKillProcessFilter(t *testing.T) {
-	api, err := GetApi()
+	api, err := GetAPI()
 	if err != nil {
-		if !ApiLevelIsSupported() {
+		if !APILevelIsSupported() {
 			t.Skipf("Skipping test: %s", err)
 		}
 


### PR DESCRIPTION
In addition to fixing the `golint` errors, this PR also adds a `golint` check to the Tavis CI tests.