### PR TITLE
RFE: seccomp userspace notification

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,9 @@ libseccomp-golang: Releases
 ===============================================================================
 https://github.com/seccomp/libseccomp-golang
 
+* Version 1.0.0 - Dec 12, 2019
+- Added support for the seccomp userspace notification API.
+
 * Version 0.9.1 - May 21, 2019
 - Minimum supported version of libseccomp bumped to v2.2.0
 - Use Libseccomp's `seccomp_version` API to retrieve library version

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
 module github.com/seccomp/libseccomp-golang
 
 go 1.14
+

--- a/go.mod
+++ b/go.mod
@@ -2,3 +2,4 @@ module github.com/seccomp/libseccomp-golang
 
 go 1.14
 
+

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/seccomp/libseccomp-golang
 
 go 1.14
-
-

--- a/seccomp.go
+++ b/seccomp.go
@@ -239,6 +239,9 @@ const (
 
 const (
 	// Userspace notification response flags
+
+	// Tells the kernel to continue executing the system call that triggered the
+	// notification. Must only be used when the notication response's error is 0.
 	NotifRespFlagContinue uint32 = 1
 )
 

--- a/seccomp.go
+++ b/seccomp.go
@@ -110,7 +110,7 @@ type ScmpNotifData struct {
 // Data:  system call context that triggered the notification
 //
 type ScmpNotifReq struct {
-	Id    uint64        `json:"id,omitempty"`
+	ID    uint64        `json:"id,omitempty"`
 	Pid   uint32        `json:"pid,omitempty"`
 	Flags uint32        `json:"flags,omitempty"`
 	Data  ScmpNotifData `json:"data,omitempty"`
@@ -128,7 +128,7 @@ type ScmpNotifReq struct {
 // Flags: userspace notification response flag (e.g., NotifRespFlagContinue)
 //
 type ScmpNotifResp struct {
-	Id    uint64 `json:"id,omitempty"`
+	ID    uint64 `json:"id,omitempty"`
 	Error int32  `json:"error,omitempty"`
 	Val   uint64 `json:"val,omitempty"`
 	Flags uint32 `json:"flags,omitempty"`
@@ -249,8 +249,9 @@ const (
 const (
 	// Userspace notification response flags
 
-	// Tells the kernel to continue executing the system call that triggered the
-	// notification. Must only be used when the notication response's error is 0.
+	// NotifRespFlagContinue tells the kernel to continue executing the system
+	// call that triggered the notification. Must only be used when the notication
+	// response's error is 0.
 	NotifRespFlagContinue uint32 = 1
 )
 
@@ -425,8 +426,8 @@ func GetLibraryVersion() (major, minor, micro uint) {
 // API level could not be detected due to the library being older than v2.4.0.
 // See the seccomp_api_get(3) man page for details on available API levels:
 // https://github.com/seccomp/libseccomp/blob/master/doc/man/man3/seccomp_api_get.3
-func GetApi() (uint, error) {
-	api, err := getApi()
+func GetAPI() (uint, error) {
+	api, err := getAPI()
 	if err != nil {
 		return api, err
 	}
@@ -440,8 +441,8 @@ func GetApi() (uint, error) {
 // returned if the library is older than v2.4.0
 // See the seccomp_api_get(3) man page for details on available API levels:
 // https://github.com/seccomp/libseccomp/blob/master/doc/man/man3/seccomp_api_get.3
-func SetApi(api uint) error {
-	if err := setApi(api); err != nil {
+func SetAPI(api uint) error {
+	if err := setAPI(api); err != nil {
 		return err
 	}
 	apiLevel = api
@@ -625,8 +626,8 @@ func NewFilter(defaultAction ScmpAction) (*ScmpFilter, error) {
 	return filter, nil
 }
 
-// Sets or clears the filter's thread-sync (TSYNC) attribute. When set, this attribute tells
-// the kernel to synchronize all threads of the calling process to the same seccomp filter.
+// SetTsync sets or clears the filter's thread-sync (TSYNC) attribute. When set, this attribute
+// tells the kernel to synchronize all threads of the calling process to the same seccomp filter.
 // When using filters with the seccomp notification action (ActNotify), the TSYNC attribute
 // must be cleared prior to loading the filter. Refer to the seccomp manual page (seccomp(2)) for
 // further details.
@@ -1135,10 +1136,10 @@ func NotifRespond(fd ScmpFd, scmpResp *ScmpNotifResp) error {
 	return nil
 }
 
-// NotifIdValid checks if a notification is still valid. An return value of nil means the
+// NotifIDValid checks if a notification is still valid. An return value of nil means the
 // notification is still valid. Otherwise the notification is not valid. This can be used
 // to mitigate time-of-check-time-of-use (TOCTOU) attacks as described in seccomp_notify_id_valid(2).
-func NotifIdValid(fd ScmpFd, id uint64) error {
+func NotifIDValid(fd ScmpFd, id uint64) error {
 	if apiLevel < 5 {
 		return fmt.Errorf("seccomp notification requires API level >= 5; current level = %d", apiLevel)
 	}

--- a/seccomp.go
+++ b/seccomp.go
@@ -21,7 +21,7 @@ import (
 // C wrapping code
 
 // #cgo CFLAGS: -I../seccomp/include
-// #cgo LDFLAGS: -static -L../seccomp/src/.libs -lseccomp
+// #cgo LDFLAGS: -L../seccomp/src/.libs -l:libseccomp.a
 // #include <stdlib.h>
 // #include <seccomp.h>
 import "C"

--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -641,6 +641,6 @@ func notifReqFromNative(req *C.struct_seccomp_notif) (*ScmpNotifReq, error) {
 func (scmpResp *ScmpNotifResp) toNative(resp *C.struct_seccomp_notif_resp) {
 	resp.id = C.__u64(scmpResp.Id)
 	resp.val = C.__s64(scmpResp.Val)
-	resp.error = C.__s32(scmpResp.Error)
+	resp.error = (C.__s32(scmpResp.Error) * -1) // kernel requires a negated value
 	resp.flags = C.__u32(scmpResp.Flags)
 }

--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -89,6 +89,7 @@ const uint32_t C_ACT_ERRNO         = SCMP_ACT_ERRNO(0);
 const uint32_t C_ACT_TRACE         = SCMP_ACT_TRACE(0);
 const uint32_t C_ACT_LOG           = SCMP_ACT_LOG;
 const uint32_t C_ACT_ALLOW         = SCMP_ACT_ALLOW;
+const uint32_t C_ACT_NOTIFY        = SCMP_ACT_NOTIFY;
 
 // The libseccomp SCMP_FLTATR_CTL_LOG member of the scmp_filter_attr enum was
 // added in v2.4.0
@@ -549,6 +550,8 @@ func actionFromNative(a C.uint32_t) (ScmpAction, error) {
 		return ActLog, nil
 	case C.C_ACT_ALLOW:
 		return ActAllow, nil
+	case C.C_ACT_NOTIFY:
+		return ActNotify, nil
 	default:
 		return 0x0, fmt.Errorf("unrecognized action %#x", uint32(a))
 	}
@@ -573,6 +576,8 @@ func (a ScmpAction) toNative() C.uint32_t {
 		return C.C_ACT_LOG
 	case ActAllow:
 		return C.C_ACT_ALLOW
+	case ActNotify:
+		return C.C_ACT_NOTIFY
 	default:
 		return 0x0
 	}

--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -15,7 +15,7 @@ import (
 // Need stdlib.h for free() on cstrings
 
 // #cgo CFLAGS: -I../seccomp/include
-// #cgo LDFLAGS: -L../seccomp/src/.libs -lseccomp
+// #cgo LDFLAGS: -static -L../seccomp/src/.libs -lseccomp
 /*
 #include <errno.h>
 #include <stdlib.h>

--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -15,7 +15,7 @@ import (
 // Need stdlib.h for free() on cstrings
 
 // #cgo CFLAGS: -I../seccomp/include
-// #cgo LDFLAGS: -static -L../seccomp/src/.libs -lseccomp
+// #cgo LDFLAGS: -L../seccomp/src/.libs -l:libseccomp.a
 /*
 #include <errno.h>
 #include <stdlib.h>

--- a/seccomp_test.go
+++ b/seccomp_test.go
@@ -742,7 +742,7 @@ func notifHandler(ch chan error, fd ScmpFd, tests []notifTest) {
 
 		// TOCTOU check
 		if err := NotifIdValid(fd, req.Id); err != nil {
-			ch <- fmt.Errorf("TOCTOU check failed: req.Id is no longer valid: %s\n", err)
+			ch <- fmt.Errorf("TOCTOU check failed: req.Id is no longer valid: %s", err)
 			return
 		}
 

--- a/seccomp_test.go
+++ b/seccomp_test.go
@@ -611,7 +611,7 @@ func TestLogAct(t *testing.T) {
 		t.Skipf("Skipping test: API level %d is less than 3", api)
 	}
 
-	filter, err := NewFilter(ActErrno.SetReturnCode(0x0001))
+	filter, err := NewFilter(ActAllow)
 	if err != nil {
 		t.Errorf("Error creating filter: %s", err)
 	}
@@ -622,39 +622,9 @@ func TestLogAct(t *testing.T) {
 		t.Errorf("Error getting syscall number of getpid: %s", err)
 	}
 
-	call1, err := GetSyscallFromName("write")
-	if err != nil {
-		t.Errorf("Error getting syscall number of write: %s", err)
-	}
-
-	call2, err := GetSyscallFromName("futex")
-	if err != nil {
-		t.Errorf("Error getting syscall number of futex: %s", err)
-	}
-
-	call3, err := GetSyscallFromName("exit_group")
-	if err != nil {
-		t.Errorf("Error getting syscall number of exit_group: %s", err)
-	}
-
 	err = filter.AddRule(call, ActLog)
 	if err != nil {
 		t.Errorf("Error adding rule to log syscall: %s", err)
-	}
-
-	err = filter.AddRule(call1, ActAllow)
-	if err != nil {
-		t.Errorf("Error adding rule to allow write syscall: %s", err)
-	}
-
-	err = filter.AddRule(call2, ActAllow)
-	if err != nil {
-		t.Errorf("Error adding rule to allow futex syscall: %s", err)
-	}
-
-	err = filter.AddRule(call3, ActAllow)
-	if err != nil {
-		t.Errorf("Error adding rule to allow exit_group syscall: %s", err)
 	}
 
 	err = filter.Load()


### PR DESCRIPTION
These changes require the latest [seccomp.h](https://github.com/seccomp/libseccomp/blob/master/include/seccomp.h.in) header from libseccomp's [master](https://github.com/seccomp/libseccomp) branch for proper compilation.

These commits add the seccomp userspace notification API present in version >= 2.4 of the libseccomp library.

This API allows userspace to get a notification when a filter configured with a notification action triggers. The trigger suspends processing of the syscall until the notification is delivered to userspace and acknowledged back.