### PR TITLE
RFE: add defines for PARISC / PARISC64 goloang bindings

### DIFF
--- a/seccomp.go
+++ b/seccomp.go
@@ -117,6 +117,10 @@ const (
 	ArchS390 ScmpArch = iota
 	// ArchS390X represents 64-bit System z/390 syscalls
 	ArchS390X ScmpArch = iota
+	// ArchPARISC represents 32-bit PA-RISC
+	ArchPARISC ScmpArch = iota
+	// ArchPARISC64 represents 64-bit PA-RISC
+	ArchPARISC64 ScmpArch = iota
 )
 
 const (
@@ -223,6 +227,10 @@ func GetArchFromString(arch string) (ScmpArch, error) {
 		return ArchS390, nil
 	case "s390x":
 		return ArchS390X, nil
+	case "parisc":
+		return ArchPARISC, nil
+	case "parisc64":
+		return ArchPARISC64, nil
 	default:
 		return ArchInvalid, fmt.Errorf("cannot convert unrecognized string %q", arch)
 	}
@@ -263,6 +271,10 @@ func (a ScmpArch) String() string {
 		return "s390"
 	case ArchS390X:
 		return "s390x"
+	case ArchPARISC:
+		return "parisc"
+	case ArchPARISC64:
+		return "parisc64"
 	case ArchNative:
 		return "native"
 	case ArchInvalid:

--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -50,6 +50,14 @@ const uint32_t C_ARCH_BAD = ARCH_BAD;
 #define SCMP_ARCH_S390X ARCH_BAD
 #endif
 
+#ifndef SCMP_ARCH_PARISC
+#define SCMP_ARCH_PARISC ARCH_BAD
+#endif
+
+#ifndef SCMP_ARCH_PARISC64
+#define SCMP_ARCH_PARISC64 ARCH_BAD
+#endif
+
 const uint32_t C_ARCH_NATIVE       = SCMP_ARCH_NATIVE;
 const uint32_t C_ARCH_X86          = SCMP_ARCH_X86;
 const uint32_t C_ARCH_X86_64       = SCMP_ARCH_X86_64;
@@ -67,6 +75,8 @@ const uint32_t C_ARCH_PPC64        = SCMP_ARCH_PPC64;
 const uint32_t C_ARCH_PPC64LE      = SCMP_ARCH_PPC64LE;
 const uint32_t C_ARCH_S390         = SCMP_ARCH_S390;
 const uint32_t C_ARCH_S390X        = SCMP_ARCH_S390X;
+const uint32_t C_ARCH_PARISC       = SCMP_ARCH_PARISC;
+const uint32_t C_ARCH_PARISC64     = SCMP_ARCH_PARISC64;
 
 #ifndef SCMP_ACT_LOG
 #define SCMP_ACT_LOG 0x7ffc0000U
@@ -210,7 +220,7 @@ const (
 	scmpError C.int = -1
 	// Comparison boundaries to check for architecture validity
 	archStart ScmpArch = ArchNative
-	archEnd   ScmpArch = ArchS390X
+	archEnd   ScmpArch = ArchPARISC64
 	// Comparison boundaries to check for action validity
 	actionStart ScmpAction = ActKill
 	actionEnd   ScmpAction = ActKillProcess
@@ -460,6 +470,10 @@ func archFromNative(a C.uint32_t) (ScmpArch, error) {
 		return ArchS390, nil
 	case C.C_ARCH_S390X:
 		return ArchS390X, nil
+	case C.C_ARCH_PARISC:
+		return ArchPARISC, nil
+	case C.C_ARCH_PARISC64:
+		return ArchPARISC64, nil
 	default:
 		return 0x0, fmt.Errorf("unrecognized architecture %#x", uint32(a))
 	}
@@ -500,6 +514,10 @@ func (a ScmpArch) toNative() C.uint32_t {
 		return C.C_ARCH_S390
 	case ArchS390X:
 		return C.C_ARCH_S390X
+	case ArchPARISC:
+		return C.C_ARCH_PARISC
+	case ArchPARISC64:
+		return C.C_ARCH_PARISC64
 	case ArchNative:
 		return C.C_ARCH_NATIVE
 	default:


### PR DESCRIPTION
I want to close https://github.com/seccomp/libseccomp-golang/issues/9 to release v0.9.2

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>