### PR TITLE
Travis: compile with libseccomp-2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,19 @@ addons:
   apt:
     packages:
       - build-essential
-      # TODO: use the main libseccomp git repo instead of a distro package
-      - libseccomp2
-      - libseccomp-dev
+      - astyle
+      - golint
+      - gperf
 
 install:
   - go get -u golang.org/x/lint/golint
 
 # run all of the tests independently, fail if any of the tests error
 script:
+  - wget https://github.com/seccomp/libseccomp/releases/download/v2.5.0/libseccomp-2.5.0.tar.gz
+  - echo 463b688bf7d227325b5a465b6bdc3ec4 libseccomp-2.5.0.tar.gz | md5sum -c
+  - tar xf libseccomp-2.5.0.tar.gz
+  - pushd libseccomp-2.5.0 && ./configure && make && sudo make install && popd
   - make check-syntax
   - make lint
   - make check


### PR DESCRIPTION
Run the tests with libseccomp-2.5.0 instead of the version in Ubuntu Bionic. This is needed to test #50.