### PR TITLE
all: unify libseccomp version / API level checks

### DIFF
--- a/seccomp_test.go
+++ b/seccomp_test.go
@@ -62,58 +62,6 @@ func execInSubprocess(t *testing.T, f func(t *testing.T)) {
 
 // Type Function Tests
 
-type versionErrorTest struct {
-	err VersionError
-	str string
-}
-
-var versionStr = fmt.Sprintf("%d.%d.%d", verMajor, verMinor, verMicro)
-
-var versionErrorTests = []versionErrorTest{
-	{
-		VersionError{
-			"deadbeef",
-			"x.y.z",
-		},
-		"Libseccomp version too low: deadbeef: " +
-			"minimum supported is x.y.z: detected " + versionStr,
-	},
-	{
-		VersionError{
-			"",
-			"x.y.z",
-		},
-		"Libseccomp version too low: minimum supported is x.y.z: " +
-			"detected " + versionStr,
-	},
-	{
-		VersionError{
-			"deadbeef",
-			"",
-		},
-		"Libseccomp version too low: " +
-			"deadbeef: minimum supported is 2.2.0: " +
-			"detected " + versionStr,
-	},
-	{
-		VersionError{
-			"",
-			"",
-		},
-		"Libseccomp version too low: minimum supported is 2.2.0: " +
-			"detected " + versionStr,
-	},
-}
-
-func TestVersionError(t *testing.T) {
-	for i, test := range versionErrorTests {
-		str := test.err.Error()
-		if str != test.str {
-			t.Errorf("VersionError %d: got %q: expected %q", i, str, test.str)
-		}
-	}
-}
-
 func APILevelIsSupported() bool {
 	return verMajor > 2 ||
 		(verMajor == 2 && verMinor > 3) ||

--- a/seccomp_ver_test.go
+++ b/seccomp_ver_test.go
@@ -1,0 +1,66 @@
+package seccomp
+
+import (
+	"testing"
+)
+
+func TestCheckVersion(t *testing.T) {
+	for _, tc := range []struct {
+		// test input
+		op      string
+		x, y, z uint
+		// test output
+		res string // empty string if no error is expected
+	}{
+		{
+			op: "frobnicate", x: 100, y: 99, z: 7,
+			res: "frobnicate requires libseccomp >= 100.99.7 (current version: ",
+		},
+		{
+			op: "old-ver", x: 2, y: 2, z: 0, // 2.2.0 is guaranteed to succeed
+		},
+	} {
+		err := checkVersion(tc.op, tc.x, tc.y, tc.z)
+		t.Log(err)
+		if tc.res != "" { // error expected
+			if err == nil {
+				t.Errorf("case %s: expected %q-like error, got nil", tc.op, tc.res)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("case %s: expected no error, got %s", tc.op, err)
+		}
+	}
+}
+
+func TestCheckAPI(t *testing.T) {
+	for _, tc := range []struct {
+		// test input
+		op    string
+		level uint
+		ver   string
+		// test output
+		res string // empty string if no error is expected
+	}{
+		{
+			op: "deviate", level: 99, ver: "100.99.88",
+			res: "frobnicate requires libseccomp >= 100.99.7 (current version: ",
+		},
+		{
+			op: "api-0", level: 0, // API 0 will succeed
+		},
+	} {
+		err := checkAPI(tc.op, tc.level, tc.ver)
+		t.Log(err)
+		if tc.res != "" { // error expected
+			if err == nil {
+				t.Errorf("case %s: expected %q-like error, got nil", tc.op, tc.res)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("case %s: expected no error, got %s", tc.op, err)
+		}
+	}
+}


### PR DESCRIPTION
This unifies all the code that is used to check for minimally required
libseccomp version and API level and generate an error.

For errors, VersionError is reused, which is now amended with API level.

For checks, we now have checkVersion and checkAPI, which generate errors
that can be returned as is.

This removes some duplicated code and unifies error messages. As a
side benefit, a user can now check if an error was caused by an old
libseccomp and/or low API level, by using errors.As or checking if the
type is VersionError.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>