### PR TITLE
Remove undeeded CI deps and update to libseccomp 2.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,6 @@ addons:
   apt:
     packages:
       - build-essential
-      - astyle
-      - golint
       - gperf
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ language: go
 
 jobs:
   include:
-    - name: "last libseccomp 2.5.0"
+    - name: "last libseccomp 2.5"
       env:
-      - SECCOMP_VER=2.5.0
-      - SECCOMP_SHA256SUM=1ffa7038d2720ad191919816db3479295a4bcca1ec14e02f672539f4983014f3
+      - SECCOMP_VER=2.5.1
+      - SECCOMP_SHA256SUM=ee307e383c77aa7995abc5ada544d51c9723ae399768a97667d4cdb3c3a30d55
     - name: "compat libseccomp 2.4.4"
       env:
       - SECCOMP_VER=2.4.4


### PR DESCRIPTION
Hi!

I found that some unneeded dependencies were inadvertently added by commit  78c92cbc6966350c27f365890f4cd47ebb934594, so I removed them. And while I was there, I realized that libseccomp 2.5.0 was being used and update it to use 2.5.1

I couldn't run the CI on my fork, travis is not liking it anymore for some reason (it used to work before), so I _think_ the CI will pass here but not 100% sure.

Let me know what you think

Best,
Rodrigo