### PR TITLE
RFE: README.md facelift

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,31 +1,23 @@
-How to Submit Patches to the libseccomp Project
+How to Submit Patches to the libseccomp-golang Project
 ===============================================================================
 https://github.com/seccomp/libseccomp-golang
 
 This document is intended to act as a guide to help you contribute to the
-libseccomp project.  It is not perfect, and there will always be exceptions
+libseccomp-golang project.  It is not perfect, and there will always be exceptions
 to the rules described here, but by following the instructions below you
 should have a much easier time getting your work merged with the upstream
 project.
 
 ## Test Your Code Using Existing Tests
 
-There are two possible tests you can run to verify your code.  The first
-test is used to check the formatting and coding style of your changes, you
-can run the test with the following command:
-
-	# make check-syntax
-
-... if there are any problems with your changes a diff/patch will be shown
-which indicates the problems and how to fix them.
-
-The second possible test is used to ensure the sanity of your code changes
-and to test these changes against the included tests.  You can run the test
-with the following command:
+A number of tests and lint related recipes are provided in the Makefile, if
+you want to run the standard regression tests, you can execute the following:
 
 	# make check
 
-... if there are any faults or errors they will be displayed.
+In order to use it, the 'golangci-lint' tool is needed, which can be found at:
+
+* https://github.com/golangci/golangci-lint
 
 ## Add New Tests for New Functionality
 

--- a/README.md
+++ b/README.md
@@ -34,13 +34,6 @@ Documentation for this package is also available at:
 
 	# go get github.com/seccomp/libseccomp-golang
 
-## Testing the Library
+## Contributing
 
-A number of tests and lint related recipes are provided in the Makefile, if
-you want to run the standard regression tests, you can excute the following:
-
-	# make check
-
-In order to use it, the 'golangci-lint' tool is needed, which can be found at:
-
-* https://github.com/golangci/golangci-lint
+See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ Documentation for this package is also available at:
 
 ## Installing the package
 
-The libseccomp-golang bindings require at least Go v1.2.1 and GCC v4.8.4;
-earlier versions may yield unpredictable results.  If you meet these
-requirements you can install this package using the command below:
-
 	# go get github.com/seccomp/libseccomp-golang
 
 ## Testing the Library

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ===============================================================================
 https://github.com/seccomp/libseccomp-golang
 
-[![validate](https://github.com/seccomp/libseccomp-golang/actions/workflows/validate.yml/badge.svg)](https://github.com/seccomp/libseccomp-golang/actions/workflows/validate.yml) [![test](https://github.com/seccomp/libseccomp-golang/actions/workflows/test.yml/badge.svg)](https://github.com/seccomp/libseccomp-golang/actions/workflows/test.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/seccomp/libseccomp-golang.svg)](https://pkg.go.dev/github.com/seccomp/libseccomp-golang) [![validate](https://github.com/seccomp/libseccomp-golang/actions/workflows/validate.yml/badge.svg)](https://github.com/seccomp/libseccomp-golang/actions/workflows/validate.yml) [![test](https://github.com/seccomp/libseccomp-golang/actions/workflows/test.yml/badge.svg)](https://github.com/seccomp/libseccomp-golang/actions/workflows/test.yml)
 
 The libseccomp library provides an easy to use, platform independent, interface
 to the Linux Kernel's syscall filtering mechanism.  The libseccomp API is
@@ -26,9 +26,9 @@ list.
 
 * https://groups.google.com/d/forum/libseccomp
 
-Documentation is also available at:
+Documentation for this package is also available at:
 
-* https://godoc.org/github.com/seccomp/libseccomp-golang
+* https://pkg.go.dev/github.com/seccomp/libseccomp-golang
 
 ## Installing the package
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ===============================================================================
 https://github.com/seccomp/libseccomp-golang
 
-[![Build Status](https://img.shields.io/travis/seccomp/libseccomp-golang/main.svg)](https://travis-ci.org/seccomp/libseccomp-golang)
+[![validate](https://github.com/seccomp/libseccomp-golang/actions/workflows/validate.yml/badge.svg)](https://github.com/seccomp/libseccomp-golang/actions/workflows/validate.yml) [![test](https://github.com/seccomp/libseccomp-golang/actions/workflows/test.yml/badge.svg)](https://github.com/seccomp/libseccomp-golang/actions/workflows/test.yml)
 
 The libseccomp library provides an easy to use, platform independent, interface
 to the Linux Kernel's syscall filtering mechanism.  The libseccomp API is


### PR DESCRIPTION
1. Remove travis, add GHA CI badge
2. Add pkg.go.dev badge
3. Remove old go/gcc version requirement
4. Dedup the testing notes, referring from README to CONTRIBUTING.

Please see individual commits for more details.

Fixes: #68
Addresses: #40

The badges part (result of the first two commits) should look like this:

[![Go Reference](https://pkg.go.dev/badge/github.com/seccomp/libseccomp-golang.svg)](https://pkg.go.dev/github.com/seccomp/libseccomp-golang) [![validate](https://github.com/seccomp/libseccomp-golang/actions/workflows/validate.yml/badge.svg)](https://github.com/seccomp/libseccomp-golang/actions/workflows/validate.yml) [![test](https://github.com/seccomp/libseccomp-golang/actions/workflows/test.yml/badge.svg)](https://github.com/seccomp/libseccomp-golang/actions/workflows/test.yml)

History:
* v2: also fixed doc link in the text
* v3: add the "dedup testing notes" commit