### PR TITLE
CI/GHA: add codespell check, fix typos found

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,4 +24,12 @@ jobs:
           # must be specified without patch version
           version: v1.41
 
-
+  codespell:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: install deps
+      # Version of codespell bundled with Ubuntu is way old, so use pip.
+      run: pip install codespell
+    - name: run codespell
+      run: codespell

--- a/seccomp.go
+++ b/seccomp.go
@@ -259,7 +259,7 @@ const (
 	// Userspace notification response flags
 
 	// NotifRespFlagContinue tells the kernel to continue executing the system
-	// call that triggered the notification. Must only be used when the notication
+	// call that triggered the notification. Must only be used when the notification
 	// response's error is 0.
 	NotifRespFlagContinue uint32 = 1
 )

--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -815,7 +815,7 @@ func notifRespond(fd ScmpFd, scmpResp *ScmpNotifResp) error {
 		return err
 	}
 
-	// we only use the reponse here; the request is discarded
+	// we only use the response here; the request is discarded
 	if retCode := C.seccomp_notify_alloc(&req, &resp); retCode != 0 {
 		return errRc(retCode)
 	}

--- a/seccomp_test.go
+++ b/seccomp_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // execInSubprocess calls the go test binary again for the same test.
-// This must be only top-level statment in the test function. Do not nest this.
+// This must be only top-level statement in the test function. Do not nest this.
 // It will slightly defect the test log output as the test is entered twice
 func execInSubprocess(t *testing.T, f func(t *testing.T)) {
 	const subprocessEnvKey = `GO_SUBPROCESS_KEY`
@@ -137,7 +137,7 @@ func TestSyscallGetName(t *testing.T) {
 
 	_, err = callFail.GetName()
 	if err == nil {
-		t.Errorf("Getting nonexistant syscall should error!")
+		t.Errorf("Getting nonexistent syscall should error!")
 	}
 }
 
@@ -360,10 +360,10 @@ func TestFilterArchFunctions(t *testing.T) {
 		t.Errorf("Arch not added to filter is present")
 	}
 
-	// Try removing the nonexistant arch - should succeed
+	// Try removing the nonexistent arch - should succeed
 	err = filter.RemoveArch(prospectiveArch)
 	if err != nil {
-		t.Errorf("Error removing nonexistant arch: %s", err)
+		t.Errorf("Error removing nonexistent arch: %s", err)
 	}
 
 	// Add an arch, see if it's in the filter
@@ -420,7 +420,7 @@ func TestFilterAttributeGettersAndSetters(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error getting bad arch action")
 	} else if act != ActAllow {
-		t.Errorf("Bad arch action was not set correcly!")
+		t.Errorf("Bad arch action was not set correctly!")
 	}
 
 	err = filter.SetNoNewPrivsBit(false)


### PR DESCRIPTION
Inspired by https://github.com/seccomp/libseccomp-golang/pull/69#discussion_r708555090

 1. Fix a few typos found by codespell:
    
    ./seccomp_internal.go:820: reponse ==> response
    ./seccomp.go:267: notication ==> notification
    ./seccomp_test.go:19: statment ==> statement
    ./seccomp_test.go:140: nonexistant ==> nonexistent
    ./seccomp_test.go:363: nonexistant ==> nonexistent
    ./seccomp_test.go:366: nonexistant ==> nonexistent
    ./seccomp_test.go:423: correcly ==> correctly
    
2. Add a CI job to ensure that future PRs won't add typos (at least
   those that that are known to codespell).

~~_NOTE: this is currently a draft pending #69 merge (as it also fixes a typo). Will rebase once merged._~~