### PR TITLE
RFE: rm duplicated cgo stuff

### DIFF
--- a/seccomp.go
+++ b/seccomp.go
@@ -16,16 +16,6 @@ import (
 	"unsafe"
 )
 
-// C wrapping code
-
-// To compile libseccomp-golang against a specific version of libseccomp:
-// cd ../libseccomp && mkdir -p prefix
-// ./configure --prefix=$PWD/prefix && make && make install
-// cd ../libseccomp-golang
-// PKG_CONFIG_PATH=$PWD/../libseccomp/prefix/lib/pkgconfig/ make
-// LD_PRELOAD=$PWD/../libseccomp/prefix/lib/libseccomp.so.2.5.0 PKG_CONFIG_PATH=$PWD/../libseccomp/prefix/lib/pkgconfig/ make test
-
-// #cgo pkg-config: libseccomp
 // #include <stdlib.h>
 // #include <seccomp.h>
 import "C"


### PR DESCRIPTION
1. Only a single per-package #cgo directive is needed to link it against
   libseccomp with proper flags, and it is provided in
   seccomp_internal.go. Drop the duplicate.

2. Drop the comments telling how to link against a particular libseccomp
   version, as those are also available in seccomp_internal.go.