### PR TITLE
CompareMaskedEqual: fix doc

### DIFF
--- a/seccomp.go
+++ b/seccomp.go
@@ -236,8 +236,9 @@ const (
 	// CompareGreater returns true if the argument is greater than the given
 	// value
 	CompareGreater
-	// CompareMaskedEqual returns true if the argument is equal to the given
-	// value, when masked (bitwise &) against the second given value
+	// CompareMaskedEqual returns true if the masked argument value is
+	// equal to the masked datum value. Mask is the first argument, and
+	// datum is the second one.
 	CompareMaskedEqual
 )
 


### PR DESCRIPTION
Mask is the first argument (according to `seccomp_rule_add(3)`), but the
documentation says otherwise.

Fix it, using the wording closer to that of the man page.

Fixes: 1b506fc7
Fixes: #49