### PR TITLE
BUG: define ActKillThread equal to ActKill, and deprecated ActKill

### DIFF
--- a/seccomp.go
+++ b/seccomp.go
@@ -202,14 +202,14 @@ const (
 	// This action is only usable when libseccomp API level 3 or higher is
 	// supported.
 	ActLog
-	// ActKillThread kills the thread that violated the rule. It is the same as ActKill.
-	// All other threads from the same thread group will continue to execute.
-	ActKillThread
 	// ActKillProcess kills the process that violated the rule.
 	// All threads in the thread group are also terminated.
 	// This action is only usable when libseccomp API level 3 or higher is
 	// supported.
 	ActKillProcess
+	// ActKillThread kills the thread that violated the rule. It is the same as ActKill.
+	// All other threads from the same thread group will continue to execute.
+	ActKillThread = ActKill
 )
 
 const (
@@ -385,7 +385,7 @@ func (a ScmpCompareOp) String() string {
 // String returns a string representation of a seccomp match action
 func (a ScmpAction) String() string {
 	switch a & 0xFFFF {
-	case ActKill, ActKillThread:
+	case ActKillThread:
 		return "Action: Kill thread"
 	case ActKillProcess:
 		return "Action: Kill process"

--- a/seccomp.go
+++ b/seccomp.go
@@ -182,9 +182,9 @@ const (
 	// ActInvalid is a placeholder to ensure uninitialized ScmpAction
 	// variables are invalid
 	ActInvalid ScmpAction = iota
-	// ActKill kills the thread that violated the rule. It is the same as ActKillThread.
+	// ActKillThread kills the thread that violated the rule.
 	// All other threads from the same thread group will continue to execute.
-	ActKill
+	ActKillThread
 	// ActTrap throws SIGSYS
 	ActTrap
 	// ActNotify triggers a userspace notification. This action is only usable when
@@ -207,9 +207,11 @@ const (
 	// This action is only usable when libseccomp API level 3 or higher is
 	// supported.
 	ActKillProcess
-	// ActKillThread kills the thread that violated the rule. It is the same as ActKill.
+	// ActKill kills the thread that violated the rule.
 	// All other threads from the same thread group will continue to execute.
-	ActKillThread = ActKill
+	//
+	// Deprecated: use ActKillThread
+	ActKill = ActKillThread
 )
 
 const (

--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -293,7 +293,7 @@ const (
 	archStart ScmpArch = ArchNative
 	archEnd   ScmpArch = ArchRISCV64
 	// Comparison boundaries to check for action validity
-	actionStart ScmpAction = ActKill
+	actionStart ScmpAction = ActKillThread
 	actionEnd   ScmpAction = ActKillProcess
 	// Comparison boundaries to check for comparison operator validity
 	compareOpStart ScmpCompareOp = CompareNotEqual

--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -629,8 +629,6 @@ func (a ScmpCompareOp) toNative() C.int {
 func actionFromNative(a C.uint32_t) (ScmpAction, error) {
 	aTmp := a & 0xFFFF
 	switch a & 0xFFFF0000 {
-	case C.C_ACT_KILL:
-		return ActKill, nil
 	case C.C_ACT_KILL_PROCESS:
 		return ActKillProcess, nil
 	case C.C_ACT_KILL_THREAD:
@@ -655,8 +653,6 @@ func actionFromNative(a C.uint32_t) (ScmpAction, error) {
 // Only use with sanitized actions, no error handling
 func (a ScmpAction) toNative() C.uint32_t {
 	switch a & 0xFFFF {
-	case ActKill:
-		return C.C_ACT_KILL
 	case ActKillProcess:
 		return C.C_ACT_KILL_PROCESS
 	case ActKillThread:

--- a/seccomp_test.go
+++ b/seccomp_test.go
@@ -274,7 +274,7 @@ func TestFilterCreateRelease(t *testing.T) {
 		t.Errorf("Can create filter with invalid action")
 	}
 
-	filter, err := NewFilter(ActKill)
+	filter, err := NewFilter(ActKillThread)
 	if err != nil {
 		t.Errorf("Error creating filter: %s", err)
 	}
@@ -291,7 +291,7 @@ func TestFilterCreateRelease(t *testing.T) {
 }
 
 func TestFilterReset(t *testing.T) {
-	filter, err := NewFilter(ActKill)
+	filter, err := NewFilter(ActKillThread)
 	if err != nil {
 		t.Errorf("Error creating filter: %s", err)
 	}
@@ -301,7 +301,7 @@ func TestFilterReset(t *testing.T) {
 	action, err := filter.GetDefaultAction()
 	if err != nil {
 		t.Errorf("Error getting default action of filter")
-	} else if action != ActKill {
+	} else if action != ActKillThread {
 		t.Errorf("Default action of filter was set incorrectly!")
 	}
 
@@ -326,7 +326,7 @@ func TestFilterReset(t *testing.T) {
 }
 
 func TestFilterArchFunctions(t *testing.T) {
-	filter, err := NewFilter(ActKill)
+	filter, err := NewFilter(ActKillThread)
 	if err != nil {
 		t.Errorf("Error creating filter: %s", err)
 	}
@@ -402,7 +402,7 @@ func TestFilterArchFunctions(t *testing.T) {
 }
 
 func TestFilterAttributeGettersAndSetters(t *testing.T) {
-	filter, err := NewFilter(ActKill)
+	filter, err := NewFilter(ActKillThread)
 	if err != nil {
 		t.Errorf("Error creating filter: %s", err)
 	}
@@ -411,7 +411,7 @@ func TestFilterAttributeGettersAndSetters(t *testing.T) {
 	act, err := filter.GetDefaultAction()
 	if err != nil {
 		t.Errorf("Error getting default action: %s", err)
-	} else if act != ActKill {
+	} else if act != ActKillThread {
 		t.Errorf("Default action was set incorrectly")
 	}
 
@@ -547,7 +547,7 @@ func TestMergeFilters(t *testing.T) {
 		t.Errorf("Source filter should not be valid after merging")
 	}
 
-	filter3, err := NewFilter(ActKill)
+	filter3, err := NewFilter(ActKillThread)
 	if err != nil {
 		t.Errorf("Error creating filter: %s", err)
 	}


### PR DESCRIPTION
- Carry of / closes https://github.com/seccomp/libseccomp-golang/pull/85 (second commit is new)
- relates to / addresses https://github.com/seccomp/libseccomp-golang/issues/89
- relates to / addresses https://github.com/moby/buildkit/pull/2584

> These constants are [equal in libseccomp][1], with ActKillThread being a more
> precise name for the previous behavior, but Go definitions were defined separately
> in 24f29379854785de68bbd44630cc093b22b4dc29.
> 
> This resulted in [dead code][2] that never executed due to identical case statements
> in switch. Go can [usually][3] detect these error cases and refuses to build but
> for some reason this detection doesn’t work with cgo+gcc.
> 
> Clang detects the equal constants correctly and therefore `libseccomp-golang` builds
> with clang broke after `ActKillThread` was added making it impossible for us to
> build the latest `runc`. https://gist.github.com/tonistiigi/ab6ef71781b7e3c5cabcb71a286a9243
> is a simple example showing this condition where builds with clang fail.
> 
> In order to fix the clang build only removal of the switch case is needed. But I
> assumed that [the setter/getter logic][4] is supposed to work for `ActKillThread`
> as well and the only way to ensure that is to set them equal like they are in C.

[1]: https://github.com/seccomp/libseccomp/commit/b2f15f3d02f302b12b9d1a37d83521e6f9e08841#diff-26b243770fb00079467cda2a0d84f4d3d4158e565eac4570f12b08cbfe172be2R255
[2]: https://github.com/seccomp/libseccomp-golang/commit/24f29379854785de68bbd44630cc093b22b4dc29#diff-e4bc90dec05206f6ee3b16a8b0bb5a6a6b89face1b97420f5b4d437ee12f7cf5R539-R540
[3]: https://go.dev/play/p/QHFMuzVfW0o
[4]: https://github.com/seccomp/libseccomp-golang/blob/2a71848205430267e34457b3b771a37e7d584956/seccomp_test.go#L405-L416