### PR TITLE
RFE: bump the versions in the GH actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x]
-        libseccomp: ["v2.3.3", "v2.4.3", "v2.5.2", "HEAD"]
+        go-version: [1.16.x, 1.17.x, 1.18.x]
+        libseccomp: ["v2.3.3", "v2.4.3", "v2.5.4", "HEAD"]
 
     steps:
 


### PR DESCRIPTION
According to the Go release policy[1], only the two most recent releases are supported:

> Each major Go release is supported until there are two newer major releases. For example, Go 1.5 was supported until the Go 1.7 release, and Go 1.6 was supported until the Go 1.8 release. We fix critical problems, including critical security problems, in supported releases as needed by issuing minor revisions (for example, Go 1.6.1, Go 1.6.2, and so on).

... and with Go v1.18 being the most recent major release, trim the Go versions to the two supported 1.18.x and 1.17.x, leaving 1.16.x as it remains part of the GH Ubuntu 20.04 environment even though it is officially unsupported.  Go 1.15.x is dropped from the test matrix.

We also update the core libseccomp library to the latest v2.5.x release, which is v2.5.4 as of April 21, 2022.  The previous libseccomp versions are left untouched in the test matrix, even though they are no longer supported upstream.

[1] https://go.dev/doc/devel/release#policy

Signed-off-by: Paul Moore <paul@paul-moore.com>