### PR TITLE
RFE: bump versions of various GH actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,11 @@ jobs:
     steps:
 
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: install go ${{ matrix.go-version }}
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        stable: '!contains(${{ matrix.go-version }}, "beta") && !contains(${{ matrix.go-version }}, "rc")'
         go-version: ${{ matrix.go-version }}
 
     - name: build libseccomp ${{ matrix.libseccomp }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,20 +14,19 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: install deps
         run: |
           sudo apt -q update
           sudo apt -q install libseccomp-dev
-      - uses: golangci/golangci-lint-action@v2
+      - uses: golangci/golangci-lint-action@v3
         with:
-          # must be specified without patch version
-          version: v1.41
+          version: v1.45
 
   codespell:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: install deps
       # Version of codespell bundled with Ubuntu is way old, so use pip.
       run: pip install codespell


### PR DESCRIPTION
This is mostly cosmetical, although I guess some old actions might stop working for future versions of GH environment.

Bumps:

 * Update actions/checkout, actions/setup-go,
   golangci/golangci-lint-action from v2 to v3.

 * Bump golangci-lint to v1.45.

Cleanups:

 * Remove "stable" parameter for setup-go (not needed since v3,
   see [1]).

 * Remove the obsoleted comment for golangci-lint (no longer
   true, see [2]).

[1] https://github.com/actions/setup-go/releases/tag/v3.0.0
[2] https://github.com/golangci/golangci-lint-action/pull/167