### PR TITLE
RFE: error returning nitpicks

### DIFF
--- a/seccomp.go
+++ b/seccomp.go
@@ -7,6 +7,7 @@
 package seccomp
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -245,8 +246,8 @@ const (
 )
 
 // ErrSyscallDoesNotExist represents an error condition where
-// libseccomp is unable to resolve the syscall
-var ErrSyscallDoesNotExist = fmt.Errorf("could not resolve syscall name")
+// libseccomp is unable to resolve the syscall.
+var ErrSyscallDoesNotExist = errors.New("could not resolve syscall name")
 
 const (
 	// Userspace notification response flags
@@ -556,7 +557,7 @@ func MakeCondition(arg uint, comparison ScmpCompareOp, values ...uint64) (ScmpCo
 	} else if len(values) > 2 {
 		return condStruct, fmt.Errorf("conditions can have at most 2 arguments (%d given)", len(values))
 	} else if len(values) == 0 {
-		return condStruct, fmt.Errorf("must provide at least one value to compare against")
+		return condStruct, errors.New("must provide at least one value to compare against")
 	}
 
 	condStruct.Argument = arg
@@ -611,7 +612,7 @@ func NewFilter(defaultAction ScmpAction) (*ScmpFilter, error) {
 
 	fPtr := C.seccomp_init(defaultAction.toNative())
 	if fPtr == nil {
-		return nil, fmt.Errorf("could not create filter")
+		return nil, errors.New("could not create filter")
 	}
 
 	filter := new(ScmpFilter)
@@ -695,7 +696,7 @@ func (f *ScmpFilter) Merge(src *ScmpFilter) error {
 	defer src.lock.Unlock()
 
 	if !src.valid || !f.valid {
-		return fmt.Errorf("one or more of the filter contexts is invalid or uninitialized")
+		return errors.New("one or more of the filter contexts is invalid or uninitialized")
 	}
 
 	// Merge the filters

--- a/seccomp.go
+++ b/seccomp.go
@@ -623,7 +623,7 @@ func NewFilter(defaultAction ScmpAction) (*ScmpFilter, error) {
 	// If the kernel does not support TSYNC, allow us to continue without error.
 	if err := filter.setFilterAttr(filterAttrTsync, 0x1); err != nil && err != syscall.ENOTSUP {
 		filter.Release()
-		return nil, fmt.Errorf("could not create filter - error setting tsync bit: %v", err)
+		return nil, fmt.Errorf("could not create filter: error setting tsync bit: %w", err)
 	}
 
 	return filter, nil
@@ -702,7 +702,7 @@ func (f *ScmpFilter) Merge(src *ScmpFilter) error {
 	if retCode := C.seccomp_merge(f.filterCtx, src.filterCtx); retCode != 0 {
 		e := errRc(retCode)
 		if e == syscall.EINVAL {
-			return fmt.Errorf("filters could not be merged due to a mismatch in attributes or invalid filter")
+			return fmt.Errorf("filters could not be merged due to a mismatch in attributes or invalid filter: %w", e)
 		}
 		return e
 	}

--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -340,7 +340,7 @@ func ensureSupportedVersion() error {
 func getAPI() (uint, error) {
 	api := C.seccomp_api_get()
 	if api == 0 {
-		return 0, fmt.Errorf("API level operations are not supported")
+		return 0, errors.New("API level operations are not supported")
 	}
 
 	return uint(api), nil
@@ -351,7 +351,7 @@ func setAPI(api uint) error {
 	if retCode := C.seccomp_api_set(C.uint(api)); retCode != 0 {
 		e := errRc(retCode)
 		if e == syscall.EOPNOTSUPP {
-			return fmt.Errorf("API level operations are not supported")
+			return errors.New("API level operations are not supported")
 		}
 
 		return fmt.Errorf("could not set API level: %w", e)
@@ -412,7 +412,7 @@ func (f *ScmpFilter) setFilterAttr(attr scmpFilterAttr, value C.uint32_t) error 
 // Wrapper for seccomp_rule_add_... functions
 func (f *ScmpFilter) addRuleWrapper(call ScmpSyscall, action ScmpAction, exact bool, length C.uint, cond C.scmp_cast_t) error {
 	if length != 0 && cond == nil {
-		return fmt.Errorf("null conditions list, but length is nonzero")
+		return errors.New("null conditions list, but length is nonzero")
 	}
 
 	var retCode C.int
@@ -431,7 +431,7 @@ func (f *ScmpFilter) addRuleWrapper(call ScmpSyscall, action ScmpAction, exact b
 		case syscall.EPERM, syscall.EACCES:
 			return errDefAction
 		case syscall.EINVAL:
-			return fmt.Errorf("two checks on same syscall argument")
+			return errors.New("two checks on same syscall argument")
 		default:
 			return e
 		}
@@ -456,7 +456,7 @@ func (f *ScmpFilter) addRuleGeneric(call ScmpSyscall, action ScmpAction, exact b
 	} else {
 		argsArr := C.make_arg_cmp_array(C.uint(len(conds)))
 		if argsArr == nil {
-			return fmt.Errorf("error allocating memory for conditions")
+			return errors.New("error allocating memory for conditions")
 		}
 		defer C.free(argsArr)
 
@@ -496,7 +496,7 @@ func sanitizeAction(in ScmpAction) error {
 	}
 
 	if inTmp != ActTrace && inTmp != ActErrno && (in&0xFFFF0000) != 0 {
-		return fmt.Errorf("highest 16 bits must be zeroed except for Trace and Errno")
+		return errors.New("highest 16 bits must be zeroed except for Trace and Errno")
 	}
 
 	return nil

--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -349,11 +349,12 @@ func getAPI() (uint, error) {
 // Set the API level
 func setAPI(api uint) error {
 	if retCode := C.seccomp_api_set(C.uint(api)); retCode != 0 {
-		if errRc(retCode) == syscall.EOPNOTSUPP {
+		e := errRc(retCode)
+		if e == syscall.EOPNOTSUPP {
 			return fmt.Errorf("API level operations are not supported")
 		}
 
-		return fmt.Errorf("could not set API level: %v", retCode)
+		return fmt.Errorf("could not set API level: %w", e)
 	}
 
 	return nil


### PR DESCRIPTION
A few error returning nits which I guess better be done before the v0.10.0 release.

1. Use `errors.New` instead of `fmt.Errorf` where appropriate (as promised in commit a4551a5f7bd4d6995a39c778350aaccfb8839f1f).
2. Wrap the original error from libseccomp so that users can check for it.

Please see individual commit messages for details.