### PR TITLE
doc: init: add libseccomp version and TODO to comment

### DIFF
--- a/seccomp.go
+++ b/seccomp.go
@@ -33,8 +33,9 @@ type VersionError struct {
 
 func init() {
 	// This forces the cgo libseccomp to initialize its internal API support state,
-	// which is necessary on older versions of libseccomp in order to work
+	// which is necessary on older versions of libseccomp (< 2.5.0) in order to work
 	// correctly.
+	// TODO: remove once libseccomp < v2.5.0 is not supported.
 	_, _ = getAPI()
 }
 


### PR DESCRIPTION
It was not clear from the commit 78c92cbc6966 what versions of
libseccomp require this kludge.

Looks like the issue in question was fixed by libseccomp commit
88afa50ff7c9787 ("api: force an API level update when necessary") which
made its way to libseccomp v2.5.0.

Amend the comment to tell the version, and add a TODO item to remove the
workaround.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>