### PR TITLE
Add support for LoongArch64

### DIFF
--- a/seccomp.go
+++ b/seccomp.go
@@ -176,6 +176,8 @@ const (
 	ArchPARISC64
 	// ArchRISCV64 represents RISCV64
 	ArchRISCV64
+	// ArchLOONG64 represents 64-bit LoongArch syscalls
+	ArchLOONG64
 )
 
 const (
@@ -307,6 +309,8 @@ func GetArchFromString(arch string) (ScmpArch, error) {
 		return ArchPARISC64, nil
 	case "riscv64":
 		return ArchRISCV64, nil
+	case "loong64", "loongarch64":
+		return ArchLOONG64, nil
 	default:
 		return ArchInvalid, fmt.Errorf("cannot convert unrecognized string %q", arch)
 	}
@@ -353,6 +357,8 @@ func (a ScmpArch) String() string {
 		return "parisc64"
 	case ArchRISCV64:
 		return "riscv64"
+	case ArchLOONG64:
+		return "loong64"
 	case ArchNative:
 		return "native"
 	case ArchInvalid:

--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -88,6 +88,7 @@ const uint32_t C_ARCH_S390X        = SCMP_ARCH_S390X;
 const uint32_t C_ARCH_PARISC       = SCMP_ARCH_PARISC;
 const uint32_t C_ARCH_PARISC64     = SCMP_ARCH_PARISC64;
 const uint32_t C_ARCH_RISCV64      = SCMP_ARCH_RISCV64;
+const uint32_t C_ARCH_LOONGARCH64  = SCMP_ARCH_LOONGARCH64;
 
 #ifndef SCMP_ACT_LOG
 #define SCMP_ACT_LOG 0x7ffc0000U
@@ -270,7 +271,7 @@ const (
 	scmpError C.int = -1
 	// Comparison boundaries to check for architecture validity
 	archStart ScmpArch = ArchNative
-	archEnd   ScmpArch = ArchRISCV64
+	archEnd   ScmpArch = ArchLOONG64
 	// Comparison boundaries to check for action validity
 	actionStart ScmpAction = ActKillThread
 	actionEnd   ScmpAction = ActKillProcess
@@ -531,6 +532,8 @@ func archFromNative(a C.uint32_t) (ScmpArch, error) {
 		return ArchPARISC64, nil
 	case C.C_ARCH_RISCV64:
 		return ArchRISCV64, nil
+	case C.C_ARCH_LOONGARCH64:
+		return ArchLOONG64, nil
 	default:
 		return 0x0, fmt.Errorf("unrecognized architecture %#x", uint32(a))
 	}
@@ -577,6 +580,8 @@ func (a ScmpArch) toNative() C.uint32_t {
 		return C.C_ARCH_PARISC64
 	case ArchRISCV64:
 		return C.C_ARCH_RISCV64
+	case ArchLOONG64:
+		return C.C_ARCH_LOONGARCH64
 	case ArchNative:
 		return C.C_ARCH_NATIVE
 	default:


### PR DESCRIPTION
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.

Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html