### PR TITLE
Added LoongArch architecture name

### DIFF
--- a/seccomp.go
+++ b/seccomp.go
@@ -330,7 +330,7 @@ func GetArchFromString(arch string) (ScmpArch, error) {
 		return ArchPARISC64, nil
 	case "riscv64":
 		return ArchRISCV64, nil
-	case "loongarch64":
+	case "loong64", "loongarch64":
 		return ArchLOONGARCH64, nil
 	case "m68k":
 		return ArchM68K, nil


### PR DESCRIPTION
When running the runc test, an error message is reported: "enosys_linux_test.go:179: unknown libseccomp architecture "loong64": could convert unrecognized string "loong64"". After checking, it was found that the error was caused by the missing "loong64" in the seccomp.go file.