### PR TITLE
ci: bump Go, golangci-lint, codespell

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.23.x, 1.24.x]
         libseccomp: ["v2.3.3", "v2.4.4", "v2.5.6", "v2.6.0", "HEAD"]
 
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt -q install libseccomp-dev
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60
+          version: v1.64
 
   codespell:
     runs-on: ubuntu-24.04
@@ -30,6 +30,6 @@ jobs:
     - name: install deps
       # Version of codespell bundled with Ubuntu will become old, so use pip.
       # OTOH, we want to pin it to specific version to avoid breaking CI.
-      run: pip install --break-system-packages codespell==v2.3.0
+      run: pip install --break-system-packages codespell==v2.4.1
     - name: run codespell
       run: codespell


### PR DESCRIPTION
 - Add Go 1.24, remove Go 1.22 (no longer supported by Go team) to the test CI matrix.
 - Bump golangci-lint to v1.64.x (among the other things, it adds support for Go 1.24).
 - Bump codespell to v2.4.1 (no new typos found)