### PR TITLE
ci: add all-done jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,3 +80,10 @@ jobs:
 
     - name: test
       run: make test
+
+  all-done:
+    needs:
+      - test
+    runs-on: ubuntu-24.04
+    steps:
+    - run: echo "All jobs completed"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,3 +33,11 @@ jobs:
       run: pip install --break-system-packages codespell==v2.4.1
     - name: run codespell
       run: codespell
+
+  all-done:
+    needs:
+      - lint
+      - codespell
+    runs-on: ubuntu-24.04
+    steps:
+    - run: echo "All jobs completed"


### PR DESCRIPTION
This is to simplify GH branch protection rules (to disable merging unless all the tests have succeeded).