### PR TITLE
ci: bump golangci-lint to v2

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,9 +19,9 @@ jobs:
         run: |
           sudo apt -q update
           sudo apt -q install libseccomp-dev
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
+          version: v2.1
 
   codespell:
     runs-on: ubuntu-24.04

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,12 @@
 # For documentation, see https://golangci-lint.run/usage/configuration/
-linters:
+version: "2"
+
+formatters:
   enable:
     - gofumpt
+
+linters:
+  exclusions:
+    generated: disable
+    presets:
+      - std-error-handling


### PR DESCRIPTION
The configuration file format has changed.

Initially created via golangci-lint migrate, then edited to simplify.