### PR TITLE
CHANGELOG: v0.11.1 changes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,9 @@ libseccomp-golang: Releases
 ===============================================================================
 https://github.com/seccomp/libseccomp-golang
 
+* Version 0.11.1 - August 5, 2025
+- Make GetArchFromString recognize "loong64"
+
 * Version 0.11.0 - April 23, 2025
 - Add new architectures (LOONGARCH64, M68K, SH, SHEB)
 - Add support for SCMP_FLTATR_CTL_WAITKILL (GetWaitKill, SetWaitKill)


### PR DESCRIPTION
A copy/paste from CHANGELOG:

* Version 0.11.1 - ~~May 19, 2025~~ July 31, 2025
- Make GetArchFromString recognize "loong64"
