### PR TITLE
ci: bumps and nits, add arm64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,14 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         go-version: [1.19.x, 1.25.x, 1.26.x]
         libseccomp: ["v2.3.3", "v2.4.4", "v2.5.6", "v2.6.0", "HEAD"]
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
       - v*
     branches:
       - main
-      - master
       - release-*
   pull_request:
 
@@ -15,13 +14,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.23.x, 1.24.x]
+        go-version: [1.19.x, 1.25.x, 1.26.x]
         libseccomp: ["v2.3.3", "v2.4.4", "v2.5.6", "v2.6.0", "HEAD"]
 
     steps:
 
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: build libseccomp ${{ matrix.libseccomp }}
       run: |
@@ -65,7 +64,7 @@ jobs:
         echo "_EXPECTED_LIBSECCOMP_VERSION=$VER" >> $GITHUB_ENV
 
     - name: install go ${{ matrix.go-version }}
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
         # Add libseccomp.pc path so that setup-go adds this file hash to cache key.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,7 +4,6 @@ on:
     tags:
       - v*
     branches:
-      - master
       - main
       - release-*
   pull_request:
@@ -14,23 +13,26 @@ jobs:
   lint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
       - name: install deps
         run: |
           sudo apt -q update
           sudo apt -q install libseccomp-dev
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1
+          version: v2.11
 
   codespell:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: install deps
       # Version of codespell bundled with Ubuntu will become old, so use pip.
       # OTOH, we want to pin it to specific version to avoid breaking CI.
-      run: pip install --break-system-packages codespell==v2.4.1
+      run: pip install --break-system-packages codespell==v2.4.2
     - name: run codespell
       run: codespell
 


### PR DESCRIPTION
This upgrades some CI components:
 - various github actions used for CI
 - golangci-lint
 - go (removed 1.23.x, added 1.25.x)

In addition to that,
 - make sure latest Go is used for linting action;
 - drop master branch from jobs as we don't have it.
 
 Finally,
 - add arm64 CI run